### PR TITLE
Add code coverage upload to codecov.io in continuous integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,8 @@ jobs:
         uses: aganders3/headless-gui@v1
         with:
           run: hatch -v run +backend=${{ matrix.backend }} test:run
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,5 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,18 @@ matrix.backend.features = [
         "pyside6",
     ] },
 ]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "@overload",
+    "except ImportError",
+    "except ImportError*",
+    "raise NotImplementedError()",
+    "pass",
+    "\\.\\.\\.",
+]
+omit = [
+    "test_waitingspinnerwidget.py",
+]


### PR DESCRIPTION
Upload code coverage results to codecov.io
Do not fail CI tests if coverage decreases, this is currently just for informational purposes.